### PR TITLE
add post deletion confirmation message

### DIFF
--- a/blog/templates/blog/profile.html
+++ b/blog/templates/blog/profile.html
@@ -4,16 +4,16 @@
     <h2>My Profile</h2>
     <a href="{% url 'create_post' %}" class="btn btn-primary mb-3">Create New Post</a>
     <h3>My Posts</h3>
-    <div class="row">
+    <div class="row" id="post-list">
         {% for post in posts %}
-        <div class="col-md-4 mb-4">
+        <div class="col-md-4 mb-4" id="post-{{ post.id }}">
             <div class="card">
                 <img src="{{ post.featured_image.url }}" class="card-img-top" alt="{{ post.title }}">
                 <div class="card-body">
                     <h5 class="card-title">{{ post.title }}</h5>
                     <p class="card-text">{{ post.author }} | {{ post.created_on }}</p>
                     <a href="{% url 'edit_post' post.slug %}" class="btn btn-secondary">Edit</a>
-                    <a href="{% url 'delete_post' post.slug %}" class="btn btn-danger">Delete</a>
+                    <button class="btn btn-danger" data-bs-toggle="modal" data-bs-target="#deleteModal" data-post-id="{{ post.id }}" data-post-url="{% url 'delete_post' post.slug %}">Delete</button>
                 </div>
             </div>
         </div>
@@ -53,4 +53,55 @@
     </div>
     {% endif %}
 </div>
+
+<!-- Delete Confirmation Modal -->
+<div class="modal fade" id="deleteModal" tabindex="-1" aria-labelledby="deleteModalLabel" aria-hidden="true">
+    <div class="modal-dialog">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h5 class="modal-title" id="deleteModalLabel">Confirm Delete</h5>
+                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+            </div>
+            <div class="modal-body">
+                Are you sure you want to delete this post?
+            </div>
+            <div class="modal-footer">
+                <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
+                <button type="button" class="btn btn-danger" id="confirmDeleteBtn">Delete</button>
+            </div>
+        </div>
+    </div>
+</div>
+
+<script>
+    var deleteModal = document.getElementById('deleteModal');
+    deleteModal.addEventListener('show.bs.modal', function (event) {
+        var button = event.relatedTarget;
+        var postId = button.getAttribute('data-post-id');
+        var postUrl = button.getAttribute('data-post-url');
+        var confirmDeleteBtn = document.getElementById('confirmDeleteBtn');
+        confirmDeleteBtn.setAttribute('data-post-id', postId);
+        confirmDeleteBtn.setAttribute('data-post-url', postUrl);
+    });
+
+    document.getElementById('confirmDeleteBtn').addEventListener('click', function () {
+        var postId = this.getAttribute('data-post-id');
+        var postUrl = this.getAttribute('data-post-url');
+        fetch(postUrl, {
+            method: 'DELETE',
+            headers: {
+                'X-CSRFToken': '{{ csrf_token }}',
+                'Content-Type': 'application/json'
+            }
+        }).then(response => {
+            if (response.ok) {
+                document.getElementById('post-' + postId).remove();
+                var deleteModal = bootstrap.Modal.getInstance(document.getElementById('deleteModal'));
+                deleteModal.hide();
+            } else {
+                alert('Failed to delete the post.');
+            }
+        });
+    });
+</script>
 {% endblock %}


### PR DESCRIPTION
added post deletion confirmation message.
code updated to keep user in the same page as prior to post deletion and not going back to profile initial page, in case the user wants to delete more posts on the current page.
Keeping same style as message shown when selecting to delete a comment on a post.